### PR TITLE
Added "equals" helper and greatly improved tests...

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,3 +45,35 @@ Transform markdown into html.  To use this function in your handlebars templates
 
 {{md "string value"}}
 ```
+
+## equals
+
+Display content when two values match.  Values can be context variables or strings:
+
+```
+{{#equals json.baz json.qux}}true{{else}}false{{/equals}}
+
+{{#equals json.foo json.qux}}true{{else}}false{{/equals}}
+
+{{#equals json.foo "bar"}}true{{else}}false{{/equals}}
+
+{{#equals "nonsense" json.qux}}true{{else}}false{{/equals}}
+```
+
+Note that, just like the {{#if}} block provided by handlebars, the {{#equals}} block supports the use of an optional {{else}} block for cases in which the two values are not equal.
+
+
+# Testing This Module
+
+On OS X and Linux, building this module should be as simple as running the following commands in order:
+
+1. `bower install`
+2. `npm install`
+3. `grunt dedupe-infusion`
+4. `node tests/all-tests.js`
+
+## Testing on Windows
+
+This module uses [Zombie](http://zombie.labnotes.org/) for client-side testing.  This requires "contextify", which cannot be automatically built under windows because of problems with `node-gyp` in that environment.
+
+To run the `npm install` command for this module under windows, you will need to follow [the instructions for installing `node-gyp`](https://github.com/TooTallNate/node-gyp/wiki/Visual-Studio-2010-Setup) first, and save "contextify" to your local npm cache using `npm install`.


### PR DESCRIPTION
I needed a bit more conditional formatting than handlebars' {{#if}} blocks can reasonably support without having to pollute the data model with display variables (shouldDisplayThis, etc.).  To assist with this, I created an "equals" helper that tests the equality of two items (which can be either variables or literal strings).  You can see the feature request here:

http://issues.gpii.net/browse/CTR-176

As part of doing this, I had to refactor the tests.  Previously, they ran client side and only reported that all had passed or failed.  I converted these to tests that run within node rather than within zombie, so that all failures are clear from the console, CI reports, etc.

I also ended up fixing the server-side jsonify test, which had been disabled because it broke when we prettified the output of the jsonify helper.
