### PR TITLE
Fixed "two helpers" wording...

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-A helper library to assist in pulling in handlebars content both on the server and client side.  Provides two helper functions (see ["functions"](#Functions) below).
+A helper library to assist in pulling in handlebars content both on the server and client side.  Provides a handful of helper functions (see ["functions"](#Functions) below).
 
 # Server-side installation instructions
 


### PR DESCRIPTION
As we add helpers, having a count in the documentation is less helpful, as it's easy to miss updating it.  I have changed "two helpers" to "a handful of helpers".
