### PR TITLE
GPII-1684: Update `gpii.express` dependency to pick up new "static" router...

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "express-handlebars": "1.2.2",
     "gpii-binder": "git://github.com/the-t-in-rtf/gpii-binder#c83ff8cde8ba37c72f7e26bebf81c44d1a681c36",
-    "gpii-express": "git://github.com/the-t-in-rtf/gpii-express#d4eee18a0f2286624fe70c7e0565a51a9fda3d0e",
+    "gpii-express": "git://github.com/the-t-in-rtf/gpii-express#47cc039b86c5271c27ce5432a9fb6afe72b91568",
     "handlebars": "4.0.5",
     "infusion": "2.0.0-dev.20151211T025229Z.eabb4fc",
     "marked": "0.3.5",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "express-handlebars": "1.2.2",
     "gpii-binder": "git://github.com/the-t-in-rtf/gpii-binder#c83ff8cde8ba37c72f7e26bebf81c44d1a681c36",
-    "gpii-express": "git://github.com/the-t-in-rtf/gpii-express#47cc039b86c5271c27ce5432a9fb6afe72b91568",
+    "gpii-express": "git://github.com/the-t-in-rtf/gpii-express#3d0760413da426575ad962432c7160de0c046489",
     "handlebars": "4.0.5",
     "infusion": "2.0.0-dev.20151211T025229Z.eabb4fc",
     "marked": "0.3.5",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "express-handlebars": "1.2.2",
     "gpii-binder": "git://github.com/the-t-in-rtf/gpii-binder#c83ff8cde8ba37c72f7e26bebf81c44d1a681c36",
-    "gpii-express": "git://github.com/the-t-in-rtf/gpii-express#2f2b9418f02e7a4251a46fe8602ae482b5eac83e",
+    "gpii-express": "git://github.com/the-t-in-rtf/gpii-express#2f55451a019202b7abe7f5ec794a85933256f52a",
     "handlebars": "4.0.5",
     "infusion": "2.0.0-dev.20151211T025229Z.eabb4fc",
     "marked": "0.3.5",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "express-handlebars": "1.2.2",
     "gpii-binder": "git://github.com/the-t-in-rtf/gpii-binder#c83ff8cde8ba37c72f7e26bebf81c44d1a681c36",
-    "gpii-express": "git://github.com/the-t-in-rtf/gpii-express#59e852d74d5a198bb96190d47073b97fff224fd9",
+    "gpii-express": "git://github.com/the-t-in-rtf/gpii-express#d3e732ceb19bf6a0f65f2b05641f9efd232d5919",
     "handlebars": "4.0.5",
     "infusion": "2.0.0-dev.20151211T025229Z.eabb4fc",
     "marked": "0.3.5",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "express-handlebars": "1.2.2",
-    "gpii-binder": "git://github.com/the-t-in-rtf/gpii-binder#c83ff8cde8ba37c72f7e26bebf81c44d1a681c36",
+    "gpii-binder": "git://github.com/the-t-in-rtf/gpii-binder#648cbbd7933d037f650a138a225c75c217286d44",
     "gpii-express": "git://github.com/the-t-in-rtf/gpii-express#d3e732ceb19bf6a0f65f2b05641f9efd232d5919",
     "handlebars": "4.0.5",
     "infusion": "2.0.0-dev.20151211T025229Z.eabb4fc",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "express-handlebars": "1.2.2",
     "gpii-binder": "git://github.com/the-t-in-rtf/gpii-binder#c83ff8cde8ba37c72f7e26bebf81c44d1a681c36",
-    "gpii-express": "git://github.com/the-t-in-rtf/gpii-express#2f55451a019202b7abe7f5ec794a85933256f52a",
+    "gpii-express": "git://github.com/the-t-in-rtf/gpii-express#59e852d74d5a198bb96190d47073b97fff224fd9",
     "handlebars": "4.0.5",
     "infusion": "2.0.0-dev.20151211T025229Z.eabb4fc",
     "marked": "0.3.5",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "express-handlebars": "1.2.2",
     "gpii-binder": "git://github.com/the-t-in-rtf/gpii-binder#c83ff8cde8ba37c72f7e26bebf81c44d1a681c36",
-    "gpii-express": "git://github.com/the-t-in-rtf/gpii-express#3d0760413da426575ad962432c7160de0c046489",
+    "gpii-express": "git://github.com/the-t-in-rtf/gpii-express#2f2b9418f02e7a4251a46fe8602ae482b5eac83e",
     "handlebars": "4.0.5",
     "infusion": "2.0.0-dev.20151211T025229Z.eabb4fc",
     "marked": "0.3.5",

--- a/src/js/server/dispatcher.js
+++ b/src/js/server/dispatcher.js
@@ -49,6 +49,7 @@ gpii.express.dispatcher.route = function (that, req, res) {
 
 fluid.defaults("gpii.express.dispatcher", {
     gradeNames:      ["gpii.express.router", "fluid.modelComponent"],
+    namespace:       "dispatcher", // Namespace to allow other routers to put themselves in the chain before or after us.
     method:          "get",
     defaultTemplate: "index",
     defaultLayout:   "main.handlebars",

--- a/src/js/server/handlebars.js
+++ b/src/js/server/handlebars.js
@@ -66,6 +66,7 @@ gpii.express.configureExpress = function (that, expressComponent) {
 fluid.defaults("gpii.express.hb", {
     gradeNames:       ["fluid.modelComponent"],
     config:           "{expressConfigHolder}.options.config",
+    namespace:        "handlebars", // Namespace to allow other middleware to put themselves in the chain before or after us.
     members: {
         helpers: {},
         templateDirs: []

--- a/src/js/server/inline.js
+++ b/src/js/server/inline.js
@@ -93,6 +93,7 @@ gpii.express.hb.inline.scanTemplateSubdir = function (that, key, dirPath) {
 fluid.defaults("gpii.express.hb.inline", {
     gradeNames:          ["gpii.express.requestAware.router"],
     path:                "/inline",
+    namespace:           "inline", // Namespace to allow other routers to put themselves in the chain before or after us.
     hbsExtensionRegexp:  /^(.+)\.(?:hbs|handlebars)$/,
     allowedTemplateDirs: ["layouts", "partials", "pages"],
     members: {

--- a/src/js/server/singleTemplateRouter.js
+++ b/src/js/server/singleTemplateRouter.js
@@ -44,6 +44,7 @@ gpii.express.singleTemplateRouter.renderForm = function (that, request, response
 
 fluid.defaults("gpii.express.singleTemplateRouter", {
     gradeNames:      ["gpii.express.router"],
+    namespace:       "singleTemplateRouter", // Namespace to make it easier for other routers to put themselves in the chain before or after us.
     path:            "/",
     method:          "get",
     rules: {

--- a/tests/js/browser/browser-templateFormControl-tests.js
+++ b/tests/js/browser/browser-templateFormControl-tests.js
@@ -20,7 +20,14 @@ fluid.defaults("gpii.templates.tests.browser.templateFormControl.caseHolder", {
                         args: ["{gpii.templates.tests.browser.environment}.options.url"]
                     },
                     {
-                        event: "{gpii.templates.tests.browser.environment}.browser.events.onLoaded",
+                        event:    "{gpii.templates.tests.browser.environment}.browser.events.onLoaded",
+                        // Give the page time to render to avoid intermittent errors
+                        // TODO: Fix this properly once this issue is resolved: https://issues.gpii.net/browse/GPII-1574
+                        listener: "{gpii.templates.tests.browser.environment}.browser.wait",
+                        args:     ["{testEnvironment}.options.waitAfterLoad"]
+                    },
+                    {
+                        event: "{gpii.templates.tests.browser.environment}.browser.events.onWaitComplete",
                         listener: "{gpii.templates.tests.browser.environment}.browser.evaluate",
                         args: [gpii.tests.browser.tests.elementMatches, "body", "This content should not be visible"]
                     },
@@ -40,6 +47,13 @@ fluid.defaults("gpii.templates.tests.browser.templateFormControl.caseHolder", {
                     },
                     {
                         event:    "{gpii.templates.tests.browser.environment}.browser.events.onLoaded",
+                        // Give the page time to render to avoid intermittent errors
+                        // TODO: Fix this properly once this issue is resolved: https://issues.gpii.net/browse/GPII-1574
+                        listener: "{gpii.templates.tests.browser.environment}.browser.wait",
+                        args:     ["{testEnvironment}.options.waitAfterLoad"]
+                    },
+                    {
+                        event: "{gpii.templates.tests.browser.environment}.browser.events.onWaitComplete",
                         listener: "{gpii.templates.tests.browser.environment}.browser.click",
                         args:     [".readyForSuccess input[type='submit']"]
                     },
@@ -78,6 +92,13 @@ fluid.defaults("gpii.templates.tests.browser.templateFormControl.caseHolder", {
                     },
                     {
                         event:    "{gpii.templates.tests.browser.environment}.browser.events.onLoaded",
+                        // Give the page time to render to avoid intermittent errors
+                        // TODO: Fix this properly once this issue is resolved: https://issues.gpii.net/browse/GPII-1574
+                        listener: "{gpii.templates.tests.browser.environment}.browser.wait",
+                        args:     ["{testEnvironment}.options.waitAfterLoad"]
+                    },
+                    {
+                        event: "{gpii.templates.tests.browser.environment}.browser.events.onWaitComplete",
                         listener: "{gpii.templates.tests.browser.environment}.browser.click",
                         args:     [".readyForStringifySuccess input[type='submit']"]
                     },
@@ -116,6 +137,13 @@ fluid.defaults("gpii.templates.tests.browser.templateFormControl.caseHolder", {
                     },
                     {
                         event:    "{gpii.templates.tests.browser.environment}.browser.events.onLoaded",
+                        // Give the page time to render to avoid intermittent errors
+                        // TODO: Fix this properly once this issue is resolved: https://issues.gpii.net/browse/GPII-1574
+                        listener: "{gpii.templates.tests.browser.environment}.browser.wait",
+                        args:     ["{testEnvironment}.options.waitAfterLoad"]
+                    },
+                    {
+                        event: "{gpii.templates.tests.browser.environment}.browser.events.onWaitComplete",
                         listener: "{gpii.templates.tests.browser.environment}.browser.click",
                         args:     [".readyForStringSuccess input[type='submit']"]
                     },
@@ -145,6 +173,13 @@ fluid.defaults("gpii.templates.tests.browser.templateFormControl.caseHolder", {
                     },
                     {
                         event:    "{gpii.templates.tests.browser.environment}.browser.events.onLoaded",
+                        // Give the page time to render to avoid intermittent errors
+                        // TODO: Fix this properly once this issue is resolved: https://issues.gpii.net/browse/GPII-1574
+                        listener: "{gpii.templates.tests.browser.environment}.browser.wait",
+                        args:     ["{testEnvironment}.options.waitAfterLoad"]
+                    },
+                    {
+                        event: "{gpii.templates.tests.browser.environment}.browser.events.onWaitComplete",
                         listener: "{gpii.templates.tests.browser.environment}.browser.click",
                         args:     [".readyForFailure input[type='submit']"]
                     },
@@ -174,6 +209,13 @@ fluid.defaults("gpii.templates.tests.browser.templateFormControl.caseHolder", {
                     },
                     {
                         event:    "{gpii.templates.tests.browser.environment}.browser.events.onLoaded",
+                        // Give the page time to render to avoid intermittent errors
+                        // TODO: Fix this properly once this issue is resolved: https://issues.gpii.net/browse/GPII-1574
+                        listener: "{gpii.templates.tests.browser.environment}.browser.wait",
+                        args:     ["{testEnvironment}.options.waitAfterLoad"]
+                    },
+                    {
+                        event: "{gpii.templates.tests.browser.environment}.browser.events.onWaitComplete",
                         listener: "{gpii.templates.tests.browser.environment}.browser.click",
                         args:     [".readyForStringifyFailure input[type='submit']"]
                     },
@@ -203,6 +245,13 @@ fluid.defaults("gpii.templates.tests.browser.templateFormControl.caseHolder", {
                     },
                     {
                         event:    "{gpii.templates.tests.browser.environment}.browser.events.onLoaded",
+                        // Give the page time to render to avoid intermittent errors
+                        // TODO: Fix this properly once this issue is resolved: https://issues.gpii.net/browse/GPII-1574
+                        listener: "{gpii.templates.tests.browser.environment}.browser.wait",
+                        args:     ["{testEnvironment}.options.waitAfterLoad"]
+                    },
+                    {
+                        event: "{gpii.templates.tests.browser.environment}.browser.events.onWaitComplete",
                         listener: "{gpii.templates.tests.browser.environment}.browser.click",
                         args:     [".readyForStringFailure input[type='submit']"]
                     },
@@ -231,6 +280,7 @@ fluid.defaults("gpii.templates.tests.browser.templateFormControl.caseHolder", {
 gpii.templates.tests.browser.environment({
     "port": 6993,
     "path": "content/tests-templateFormControl.html",
+    waitAfterLoad: 150,
     expected: {
         record: {
             foo: "bar",

--- a/tests/js/server/dispatcher-tests.js
+++ b/tests/js/server/dispatcher-tests.js
@@ -28,7 +28,7 @@ gpii.templates.tests.server.runTests = function (that) {
 
     pages.forEach(function (page) {
         jqUnit.asyncTest("Test template handling dispatcher for page '" + page + "' ...", function () {
-            request.get(that.options.config.express.baseUrl + "dispatcher/" + page + "?myvar=queryvariable", function (error, response, body) {
+            request.get(that.options.baseUrl + "dispatcher/" + page + "?myvar=queryvariable", function (error, response, body) {
                 jqUnit.start();
 
                 gpii.templates.tests.server.isSaneResponse(error, response, body);
@@ -72,7 +72,7 @@ gpii.templates.tests.server.runTests = function (that) {
     });
 
     jqUnit.asyncTest("Test 404 handling for dispatcher...", function () {
-        request.get(that.options.config.express.baseUrl + "dispatcher/bogus", function (error, response) {
+        request.get(that.options.baseUrl + "dispatcher/bogus", function (error, response) {
             jqUnit.start();
 
             jqUnit.assertNull("There should be no errors...", error);
@@ -81,7 +81,7 @@ gpii.templates.tests.server.runTests = function (that) {
     });
 
     jqUnit.asyncTest("Test multiple view directories with dispatcher...", function () {
-        request.get(that.options.config.express.baseUrl + "dispatcher/secondary", function (error, response, body) {
+        request.get(that.options.baseUrl + "dispatcher/secondary", function (error, response, body) {
             jqUnit.start();
 
             gpii.templates.tests.server.bodyMatches("The default layout should have been used...", body, /Main Layout/);
@@ -91,7 +91,7 @@ gpii.templates.tests.server.runTests = function (that) {
     });
 
     jqUnit.asyncTest("Test overriding of content when using multiple view directories with dispatcher...", function () {
-        request.get(that.options.config.express.baseUrl + "dispatcher/overridden", function (error, response, body) {
+        request.get(that.options.baseUrl + "dispatcher/overridden", function (error, response, body) {
             jqUnit.start();
 
             gpii.templates.tests.server.bodyMatches("The layout should have come from the primary...", body, /layout found in the primary template directory/);
@@ -102,15 +102,8 @@ gpii.templates.tests.server.runTests = function (that) {
 };
 
 gpii.express({
-    config:  {
-        "express": {
-            "port" :   6904,
-            "baseUrl": "http://localhost:6904/",
-            "session": {
-                "secret": "Printer, printer take a hint-ter."
-            }
-        }
-    },
+    "port" :   6904,
+    "baseUrl": "http://localhost:6904/",
     json: { foo: "bar", baz: "quux", qux: "quux" },
     listeners: {
         "onStarted.runTests": {
@@ -120,14 +113,28 @@ gpii.express({
     },
     components: {
         "json": {
-            "type": "gpii.express.middleware.bodyparser.json"
+            "type": "gpii.express.middleware.bodyparser.json",
+            options: {
+                priority: "first"
+            }
         },
         "urlencoded": {
-            "type": "gpii.express.middleware.bodyparser.urlencoded"
+            "type": "gpii.express.middleware.bodyparser.urlencoded",
+            options: {
+                priority: "after:json"
+            }
+        },
+        handlebars: {
+            type: "gpii.express.hb",
+            options: {
+                priority: "after:urlencoded",
+                templateDirs: ["%gpii-handlebars/tests/templates/primary", "%gpii-handlebars/tests/templates/secondary"]
+            }
         },
         dispatcher: {
             type: "gpii.express.dispatcher",
             options: {
+                priority: "last",
                 path: ["/dispatcher/:template", "/dispatcher"],
                 templateDirs: ["%gpii-handlebars/tests/templates/primary", "%gpii-handlebars/tests/templates/secondary"],
                 rules: {
@@ -140,11 +147,5 @@ gpii.express({
                 }
             }
         },
-        handlebars: {
-            type: "gpii.express.hb",
-            options: {
-                templateDirs: ["%gpii-handlebars/tests/templates/primary", "%gpii-handlebars/tests/templates/secondary"]
-            }
-        }
     }
 });

--- a/tests/js/server/inline-tests.js
+++ b/tests/js/server/inline-tests.js
@@ -16,7 +16,7 @@ gpii.templates.tests.server.inline.runTests = function (that) {
     jqUnit.module("Tests for inlining of templates...");
 
     jqUnit.asyncTest("Confirm that template content is inlined...", function () {
-        request.get(that.options.config.express.baseUrl + "inline", function (error, response, body) {
+        request.get(that.options.baseUrl + "inline", function (error, response, body) {
             jqUnit.start();
 
             gpii.templates.tests.server.isSaneResponse(error, response, body);
@@ -33,15 +33,8 @@ gpii.templates.tests.server.inline.runTests = function (that) {
 };
 
 gpii.express({
-    config:  {
-        "express": {
-            "port" :   6914,
-            "baseUrl": "http://localhost:6914/",
-            "session": {
-                "secret": "Printer, printer take a hint-ter."
-            }
-        }
-    },
+    "port" :   6914,
+    "baseUrl": "http://localhost:6914/",
     json: { foo: "bar", baz: "quux", qux: "quux" },
     listeners: {
         "onStarted.runTests": {

--- a/tests/js/server/singleTemplateRouter-tests.js
+++ b/tests/js/server/singleTemplateRouter-tests.js
@@ -137,12 +137,8 @@ fluid.defaults("gpii.templates.tests.singleTemplateRouter.environment", {
             type:          "gpii.express",
             createOnEvent: "constructServer",
             options: {
-                config: {
-                    express: {
-                        port:    "{testEnvironment}.options.expressPort",
-                        baseUrl: "{testEnvironment}.options.baseUrl"
-                    }
-                },
+                port:    "{testEnvironment}.options.expressPort",
+                baseUrl: "{testEnvironment}.options.baseUrl",
                 components: {
                     urlencoded: {
                         type: "gpii.express.middleware.bodyparser.urlencoded"

--- a/tests/js/test-harness.js
+++ b/tests/js/test-harness.js
@@ -18,12 +18,6 @@ fluid.defaults("gpii.templates.tests.client.harness", {
             args: ["http://localhost:%port/", { port: "{that}.options.port"}]
         }
     },
-    config:  {
-        express: {
-            port:    "{that}.options.port",
-            baseUrl: "{that}.options.baseUrl"
-        }
-    },
     templateDirs: ["%gpii-handlebars/tests/templates/primary", "%gpii-handlebars/tests/templates/secondary"],
     components: {
         dispatcher: {


### PR DESCRIPTION
See [GPII-1684](https://issues.gpii.net/browse/GPII-1684) for details.
