### PR TITLE
NOJIRA: fixed links to Helper documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ above).  For more details, see the [renderer documentation](docs/renderer.md).
 ## Helper Functions
 
 This package provides additional handlebars block helpers that can be used in your handlebars templates.  For more
-details, see the [helpers documentation](docs/helpers.md).
+details, see the [helpers documentation](docs/helper.md).
 
 ## `initBlock` Handlebars block helper
 

--- a/docs/standaloneRenderer.md
+++ b/docs/standaloneRenderer.md
@@ -70,5 +70,5 @@ The layout defaults to `options.defaultLayout`, you can change this on the fly b
 
 Child components of this grade that extend the [`gpii.handlebars.helper`](helper.md) grade are made available as block
 helpers that can be used when rendering content.  By default, this grade includes all of the helpers provided by this
-package, with the exception of the `initBlock` helper used within the view engine..  See the
-[helpers documentation](helpers.md) for details.
+package, with the exception of the `initBlock` helper used within the view engine.  See the
+[helpers documentation](helper.md) for details.


### PR DESCRIPTION
The previous links had a superfluous 's' in them, resulting in a 404 error on retrieval.