### PR TITLE
GH-39: Update to use kettle@2.1.0 (resolves #39).

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "dependencies": {
         "chokidar": "3.5.0",
         "fluid-binder": "1.1.2",
-        "fluid-express": "1.0.17",
+        "fluid-express": "1.0.18-dev.20210121T091003Z.bfaa948.GH-49",
         "handlebars": "4.7.6",
         "infusion": "3.0.0-dev.20210114T211758Z.d345ecd74.FLUID-6145",
         "json5": "2.1.3",
@@ -30,7 +30,7 @@
         "fluid-lint-all": "1.0.0",
         "fluid-testem": "2.1.14",
         "graceful-fs": "4.2.4",
-        "kettle": "1.12.0",
+        "kettle": "2.1.0",
         "mkdirp": "1.0.4",
         "node-jqunit": "1.1.8",
         "nyc": "15.0.1",

--- a/tests/js/server/dispatcher-tests.js
+++ b/tests/js/server/dispatcher-tests.js
@@ -66,7 +66,7 @@ fluid.tests.handlebars.server.dispatcher.checkOverridenBody = function (body) {
 fluid.defaults("fluid.tests.handlebars.dispatcher.request", {
     gradeNames: ["kettle.test.request.http"],
     port: "{testEnvironment}.options.port",
-    path: {
+    url: {
         expander: {
             funcName: "fluid.stringTemplate",
             args: ["%baseUrl%endpoint", { baseUrl: "{testEnvironment}.options.baseUrl", endpoint: "{that}.options.endpoint"}]

--- a/tests/js/server/inlineMessageBundlingMiddleware-tests.js
+++ b/tests/js/server/inlineMessageBundlingMiddleware-tests.js
@@ -11,6 +11,8 @@ var jqUnit = require("node-jqunit");
 
 var request = require("request");
 
+require("./lib/fixtures");
+
 fluid.registerNamespace("fluid.tests.handlebars.inlineMessageBundlingMiddleware");
 
 fluid.tests.handlebars.inlineMessageBundlingMiddleware.verifyLanguageBundle = function (response, returnedBundle, expected) {
@@ -19,9 +21,8 @@ fluid.tests.handlebars.inlineMessageBundlingMiddleware.verifyLanguageBundle = fu
 };
 
 fluid.defaults("fluid.tests.handlebars.inlineMessageBundlingMiddleware.request.noHeaders", {
-    gradeNames: ["kettle.test.request.http"],
-    port:       "{testEnvironment}.options.port",
-    path:       "/messages"
+    gradeNames: ["fluid.test.handlebars.request"],
+    endpoint: "messages"
 });
 
 fluid.defaults("fluid.tests.handlebars.inlineMessageBundlingMiddleware.request", {
@@ -407,7 +408,7 @@ fluid.defaults("fluid.tests.handlebars.inlineMessageBundlingMiddleware.caseHolde
         queryLocaleRequest: {
             type: "fluid.tests.handlebars.inlineMessageBundlingMiddleware.request",
             options: {
-                path: "/messages?locale=en-GB"
+                endpoint: "messages?locale=en-GB"
             }
         },
         weightedLocaleRequest: {
@@ -415,7 +416,6 @@ fluid.defaults("fluid.tests.handlebars.inlineMessageBundlingMiddleware.caseHolde
             options: {
                 acceptLanguageHeaders: "fr-CH, fr;q=0.9, en;q=0.8, de;q=0.7, *;q=0.5"
             }
-
         },
         wildcardLocaleRequest: {
             type: "fluid.tests.handlebars.inlineMessageBundlingMiddleware.request",

--- a/tests/js/server/lib/fixtures.js
+++ b/tests/js/server/lib/fixtures.js
@@ -2,6 +2,24 @@
 "use strict";
 var fluid = require("infusion");
 
+fluid.defaults("fluid.test.handlebars.request", {
+    gradeNames: ["kettle.test.request.http"],
+    port:       "{testEnvironment}.options.port",
+    url: {
+        expander: {
+            funcName: "fluid.stringTemplate",
+            args: [
+                "%baseUrl%endpoint",
+                {
+                    baseUrl: "{fluid.test.express.testEnvironment}.options.baseUrl",
+                    endpoint: "{that}.options.endpoint"
+                }
+            ]
+        }
+    },
+    endpoint: ""
+});
+
 fluid.defaults("fluid.test.handlebars.environment", {
     gradeNames: ["fluid.test.express.testEnvironment"],
     port: 6984,

--- a/tests/js/server/live-reload-tests.js
+++ b/tests/js/server/live-reload-tests.js
@@ -42,7 +42,7 @@ fluid.tests.handlebars.live.verifyResults = function (body, expectedText, invert
 fluid.defaults("fluid.tests.handlebars.live.request", {
     gradeNames: ["kettle.test.request.http"],
     port:       "{testEnvironment}.options.port",
-    path:       "{testEnvironment}.options.baseUrl"
+    url:        "{testEnvironment}.options.baseUrl"
 });
 
 /**

--- a/tests/js/server/singleTemplateMiddleware-tests.js
+++ b/tests/js/server/singleTemplateMiddleware-tests.js
@@ -15,6 +15,8 @@ fluid.express.loadTestingSupport();
 var kettle = require("kettle");
 kettle.loadTestingSupport();
 
+require("./lib/fixtures");
+
 fluid.registerNamespace("fluid.tests.handlebars.singleTemplateMiddleware");
 
 // Verify the results of a request.  Accepts the following values:
@@ -55,9 +57,7 @@ fluid.tests.handlebars.singleTemplateMiddleware.verifyResults = function (respon
 };
 
 fluid.defaults("fluid.tests.handlebars.singleTemplateMiddleware.request", {
-    gradeNames: ["kettle.test.request.http"],
-    port:       "{testEnvironment}.options.port",
-    path:       "{testEnvironment}.options.baseUrl"
+    gradeNames: ["fluid.test.handlebars.request"]
 });
 
 fluid.defaults("fluid.tests.handlebars.singleTemplateMiddleware.caseHolder", {
@@ -104,12 +104,7 @@ fluid.defaults("fluid.tests.handlebars.singleTemplateMiddleware.caseHolder", {
         dataRequest: {
             type: "fluid.tests.handlebars.singleTemplateMiddleware.request",
             options: {
-                path: {
-                    expander: {
-                        funcName: "fluid.stringTemplate",
-                        args:     ["%baseUrl?myvar=query+data", { baseUrl: "{testEnvironment}.options.baseUrl"}]
-                    }
-                }
+                endpoint: "?myvar=query+data"
             }
         }
     }


### PR DESCRIPTION
See #39 for details.  This should be merged after the pull to update `fluid-express` so that we can use a non-dev release.